### PR TITLE
Use git remote to avoid PAT tokens

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,18 +33,18 @@ Imports:
   OhdsiSharing,
   Hydra
 Remotes:
-  git://github.com/ohdsi/BigKnn.git,
-  git://github.com/ohdsi/ROhdsiWebApi.git,
-  git://github.com/ohdsi/FeatureExtraction.git,
-  git://github.com/ohdsi/CohortDiagnostics.git,
-  git://github.com/ohdsi/CohortMethod.git,
-  git://github.com/ohdsi/SelfControlledCaseSeries.git,
-  git://github.com/ohdsi/SelfControlledCohort.git,
-  git://github.com/ohdsi/PatientLevelPrediction.git,
-  git://github.com/ohdsi/MethodEvaluation.git,
-  git://github.com/ohdsi/OhdsiSharing.git,
-  git://github.com/ohdsi/Hydra.git,
-  git://github.com/ohdsi/EvidenceSynthesis.git
+  url::https://github.com/OHDSI/BigKnn/archive/master.zip,
+  url::https://github.com/OHDSI/ROhdsiWebApi/archive/master.zip,
+  url::https://github.com/OHDSI/FeatureExtraction/archive/master.zip,
+  url::https://github.com/OHDSI/CohortDiagnostics/archive/master.zip,
+  url::https://github.com/OHDSI/CohortMethod/archive/master.zip,
+  url::https://github.com/OHDSI/SelfControlledCaseSeries/archive/master.zip,
+  url::https://github.com/OHDSI/SelfControlledCohort/archive/master.zip,
+  url::https://github.com/OHDSI/PatientLevelPrediction/archive/master.zip,
+  url::https://github.com/OHDSI/MethodEvaluation/archive/master.zip,
+  url::https://github.com/OHDSI/OhdsiSharing/archive/master.zip,
+  url::https://github.com/OHDSI/Hydra/archive/master.zip,
+  url::https://github.com/OHDSI/EvidenceSynthesis/archive/master.zip
 LazyData: false
 RoxygenNote: 7.1.1
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,18 +33,18 @@ Imports:
   OhdsiSharing,
   Hydra
 Remotes:
-  git::git@github.com:ohdsi/BigKnn.git,
-  git::git@github.com:ohdsi/ROhdsiWebApi.git,
-  git::git@github.com:ohdsi/FeatureExtraction.git,
-  git::git@github.com:ohdsi/CohortDiagnostics.git,
-  git::git@github.com:ohdsi/CohortMethod.git,
-  git::git@github.com:ohdsi/SelfControlledCaseSeries.git,
-  git::git@github.com:ohdsi/SelfControlledCohort.git,
-  git::git@github.com:ohdsi/PatientLevelPrediction.git,
-  git::git@github.com:ohdsi/MethodEvaluation.git,
-  git::git@github.com:ohdsi/OhdsiSharing.git,
-  git::git@github.com:ohdsi/Hydra.git,
-  git::git@github.com:ohdsi/EvidenceSynthesis.git
+  git://github.com/ohdsi/BigKnn.git,
+  git://github.com/ohdsi/ROhdsiWebApi.git,
+  git://github.com/ohdsi/FeatureExtraction.git,
+  git://github.com/ohdsi/CohortDiagnostics.git,
+  git://github.com/ohdsi/CohortMethod.git,
+  git://github.com/ohdsi/SelfControlledCaseSeries.git,
+  git://github.com/ohdsi/SelfControlledCohort.git,
+  git://github.com/ohdsi/PatientLevelPrediction.git,
+  git://github.com/ohdsi/MethodEvaluation.git,
+  git://github.com/ohdsi/OhdsiSharing.git,
+  git://github.com/ohdsi/Hydra.git,
+  git://github.com/ohdsi/EvidenceSynthesis.git
 LazyData: false
 RoxygenNote: 7.1.1
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: Hades
 Type: Package
 Title: Health Analytics Data-to-Evidence Suite
-Version: 0.0.2
-Date: 2020-11-20
+Version: 0.0.3
+Date: 2021-01-27
 Authors@R: c(
   person("Martijn", "Schuemie", , "schuemie@ohdsi.org", role = c("aut", "cre")),
   person("Observational Health Data Science and Informatics", role = c("cph"))
@@ -43,7 +43,8 @@ Remotes:
   ohdsi/PatientLevelPrediction,
   ohdsi/MethodEvaluation,
   ohdsi/OhdsiSharing,
-  ohdsi/Hydra
+  ohdsi/Hydra,
+  ohdsi/EvidenceSynthesis
 LazyData: false
 RoxygenNote: 7.1.1
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Hades
 Type: Package
 Title: Health Analytics Data-to-Evidence Suite
-Version: 0.0.3
+Version: 0.0.4
 Date: 2021-01-27
 Authors@R: c(
   person("Martijn", "Schuemie", , "schuemie@ohdsi.org", role = c("aut", "cre")),
@@ -33,18 +33,18 @@ Imports:
   OhdsiSharing,
   Hydra
 Remotes:
-  ohdsi/BigKnn,
-  ohdsi/ROhdsiWebApi,
-  ohdsi/FeatureExtraction,
-  ohdsi/CohortDiagnostics,
-  ohdsi/CohortMethod,
-  ohdsi/SelfControlledCaseSeries,
-  ohdsi/SelfControlledCohort,
-  ohdsi/PatientLevelPrediction,
-  ohdsi/MethodEvaluation,
-  ohdsi/OhdsiSharing,
-  ohdsi/Hydra,
-  ohdsi/EvidenceSynthesis
+  git::git@github.com:ohdsi/BigKnn.git,
+  git::git@github.com:ohdsi/ROhdsiWebApi.git,
+  git::git@github.com:ohdsi/FeatureExtraction.git,
+  git::git@github.com:ohdsi/CohortDiagnostics.git,
+  git::git@github.com:ohdsi/CohortMethod.git,
+  git::git@github.com:ohdsi/SelfControlledCaseSeries.git,
+  git::git@github.com:ohdsi/SelfControlledCohort.git,
+  git::git@github.com:ohdsi/PatientLevelPrediction.git,
+  git::git@github.com:ohdsi/MethodEvaluation.git,
+  git::git@github.com:ohdsi/OhdsiSharing.git,
+  git::git@github.com:ohdsi/Hydra.git,
+  git::git@github.com:ohdsi/EvidenceSynthesis.git
 LazyData: false
 RoxygenNote: 7.1.1
 Encoding: UTF-8


### PR DESCRIPTION
Extends upon #5 

This uses git as remotes so that you don't run into rate limiting issues and avoids the need for a GitHub PAT token.