### PR TITLE
docker build action follows OHDSI/WebAPI pattern

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,81 @@
+# When a new release is published,
+# upload image to Dockerhub.
+#
+# Requires the following repository secrets:
+# - DOCKER_IMAGE - Configured as a secret so it can be configured per fork.
+# - DOCKER_HUB_USERNAME
+# - DOCKER_HUB_ACCESS_TOKEN
+# - GITHUBPAT - The github account to use for downloading CRAN dependencies.
+#                      Needed to avoid "API rate limit exceeded" from github.
+name: Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      docker_image:
+        description: 'Override the name of the image to be deployed.'
+        default: 'ohdsi/hades'
+        type: string
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_IMAGE: ${{ inputs.docker_image || secrets.DOCKER_IMAGE }}
+    steps:
+      - uses: actions/checkout@v2
+
+      # ------------------------------------
+      # The pattern for the following steps is specified
+      # in OHDSI/WebAPI.
+
+      # Add Docker labels and tags
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+          tag-match: v(.*)
+          tag-match-group: 1
+      # Setup docker build environment
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Set build parameters
+        id: build_params
+        run: |
+          echo "::set-output name=sha8::${GITHUB_SHA::8}"
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          # Allow running the image on the architectures supported by nginx-unprivileged:alpine.
+          platforms: linux/amd64,linux/arm64
+          push: true
+          secrets: |
+            build_github_pat=${{ secrets.GITHUBPAT }}
+          build-args: |
+            GIT_BRANCH=${{ steps.docker_meta.outputs.version }}
+            GIT_COMMIT_ID_ABBREV=${{ steps.build_params.outputs.sha8 }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          # Use runtime labels from docker_meta as well as fixed labels
+          labels: |
+            ${{ steps.docker_meta.outputs.labels }}
+            maintainer=Joris Borgdorff <joris@thehyve.nl>, Lee Evans - www.ltscomputingllc.com
+            org.opencontainers.image.authors=Joris Borgdorff <joris@thehyve.nl>, Lee Evans - www.ltscomputingllc.com
+            org.opencontainers.image.vendor=OHDSI
+            org.opencontainers.image.licenses=Apache-2.0
+      - name: Inspect image
+        run: |
+          docker pull ${{ env.DOCKER_IMAGE }}:${{ steps.docker_meta.outputs.version }}
+          docker image inspect ${{ env.DOCKER_IMAGE }}:${{ steps.docker_meta.outputs.version }}

--- a/.github/workflows/release_docker.yaml
+++ b/.github/workflows/release_docker.yaml
@@ -7,7 +7,7 @@
 # - DOCKER_HUB_ACCESS_TOKEN
 # - GITHUBPAT - The github account to use for downloading CRAN dependencies.
 #                      Needed to avoid "API rate limit exceeded" from github.
-name: Release
+name: Release Docker
 
 on:
   release:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .RData
 .Ruserdata
 *.DS_Store
+GITHUBPAT.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,94 @@
+# syntax=docker/dockerfile:1
+FROM rocker/rstudio:4.2.1
+MAINTAINER Lee Evans <evans@ohdsi.org>
+
+# install OS dependencies including java and python 3
+RUN apt-get update && apt-get install -y openjdk-11-jdk liblzma-dev libbz2-dev libncurses5-dev curl python3-dev python3.venv \
+&& R CMD javareconf \
+&& rm -rf /var/lib/apt/lists/*
+
+# install utility R packages
+RUN install2.r \
+	openssl \
+	httr \
+	xml2 \
+	remotes \
+&& rm -rf /tmp/download_packages/ /tmp/*.rds
+
+# install OHDSI HADES R packages from CRAN and GitHub, temporarily adding a GitHub Personal Access Token (PAT) to the Renviron file
+RUN --mount=type=secret,id=build_github_pat \
+	cp /usr/local/lib/R/etc/Renviron /tmp/Renviron \
+        && echo "GITHUB_PAT=$(cat /run/secrets/build_github_pat)" >> /usr/local/lib/R/etc/Renviron \
+        && R -e "remotes::install_github(repo = 'OHDSI/Hades', upgrade = 'always')" \
+        && cp /tmp/Renviron /usr/local/lib/R/etc/Renviron
+
+# install useful R libraries to help RStudio users to create/use their own GitHub Personal Access Token
+RUN install2.r \
+        usethis \
+        gitcreds \
+&& rm -rf /tmp/download_packages/ /tmp/*.rds
+
+# create Python virtual environment used by the OHDSI PatientLevelPrediction R package
+ENV WORKON_HOME="/opt/.virtualenvs"
+RUN R <<EOF
+reticulate::use_python("/usr/bin/python3", required=T)
+PatientLevelPrediction::configurePython(envname='r-reticulate', envtype='python')
+reticulate::use_virtualenv("/opt/.virtualenvs/r-reticulate")
+EOF
+
+# install shiny and other R packages used by the OHDSI PatientLevelPrediction R package viewPLP() function
+# and additional model related R packages
+RUN install2.r \
+        DT \
+        markdown \
+        plotly \
+        shiny \
+        shinycssloaders \
+        shinydashboard \
+        shinyWidgets \
+        xgboost \
+&& rm -rf /tmp/download_packages/ /tmp/*.rds
+
+# install the jdbc drivers for database access using the OHDSI DatabaseConnector R package
+ENV DATABASECONNECTOR_JAR_FOLDER="/opt/hades/jdbc_drivers"
+RUN R <<EOF
+library(DatabaseConnector);
+downloadJdbcDrivers('postgresql');
+downloadJdbcDrivers('redshift');
+downloadJdbcDrivers('sql server');
+downloadJdbcDrivers('oracle');
+downloadJdbcDrivers('spark');
+EOF
+
+# Install Rserve server and client
+RUN install2.r \
+	Rserve \
+	RSclient \
+&& rm -rf /tmp/download_packages/ /tmp/*.rds
+
+# Rserve configuration
+COPY Rserv.conf /etc/Rserv.conf
+COPY startRserve.R /usr/local/bin/startRserve.R
+RUN chmod +x /usr/local/bin/startRserve.R
+
+EXPOSE 8787
+EXPOSE 6311
+
+# install supervisor process controller
+RUN apt-get update && apt-get install -y supervisor
+
+# start Rserve & RStudio using supervisor
+RUN echo "" >> /etc/supervisor/conf.d/supervisord.conf \
+	&& echo "[supervisord]" >> /etc/supervisor/conf.d/supervisord.conf \
+	&& echo "nodaemon=true" >> /etc/supervisor/conf.d/supervisord.conf \
+	&& echo "" >> /etc/supervisor/conf.d/supervisord.conf \
+	&& echo "[program:Rserve]" >> /etc/supervisor/conf.d/supervisord.conf \
+	&& echo "command=/usr/local/bin/startRserve.R" >> /etc/supervisor/conf.d/supervisord.conf \
+	&& echo "" >> /etc/supervisor/conf.d/supervisord.conf \
+	&& echo "[program:RStudio]" >> /etc/supervisor/conf.d/supervisord.conf \
+	&& echo "command=/init" >> /etc/supervisor/conf.d/supervisord.conf \
+	&& echo "" >> /etc/supervisor/conf.d/supervisord.conf \
+	&& echo "stdout_logfile=/var/log/supervisor/%(program_name)s.log" >> /etc/supervisor/conf.d/supervisord.conf \
+	&& echo "stderr_logfile=/var/log/supervisor/%(program_name)s.log" >> /etc/supervisor/conf.d/supervisord.conf
+
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/Rserv.conf
+++ b/Rserv.conf
@@ -1,0 +1,4 @@
+ remote enable
+ auth disable
+ fileio enable
+ maxinbuf 500000

--- a/startRserve.R
+++ b/startRserve.R
@@ -1,0 +1,31 @@
+#!/usr/bin/env Rscript
+#
+# Start Rserve from the command-line
+# Adopted from install2.r
+#
+# Copyright (C) 2015 Marc A. Suchard
+#
+# Released under Apache License 2.0
+
+suppressMessages(library(docopt))   
+
+## configuration for docopt
+doc <- "Usage: startRserve.r [-h] [-p PORT] [-c FILE]
+
+-c --config FILE    configuration file [default: /etc/Rserv.conf]
+-p --port PORT      TCP/IP port on which to serve [default: 6311]
+-h --help           show this help text"
+
+## docopt parsing
+opt <- docopt(doc)
+
+if (is.null(opt$port)) {
+	opt$port <- as.integer(6311)
+} else {
+	opt$port <- as.integer(opt$port)
+}
+
+if (is.null(opt$config)) opt$config <- "/etc/Rserv.conf"
+
+library(Rserve)
+run.Rserve(port = opt$port, config.file = opt$config)


### PR DESCRIPTION
This PR adds a GH action that builds and publishes a docker image whenever there is a [GH release](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases). The docker build follows the same pattern found in OHDSI/WebApi.