### PR TITLE
Add .lintr file

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,4 @@
+linters: linters_with_defaults(
+  object_name_linter(styles = "camelCase"),
+  line_length_linter(100L)
+  )


### PR DESCRIPTION
This introduces a .lintr file, aiming to establish consistent code styling across the project, as discussed in Issue #9 . These settings are based on the tidyverse style guide except these below:

- line_length_linter(100): Sets the maximum line length to 100 characters.
- object_name_linter(styles = "camelCase"): Enforces camelCase naming convention for object names.