### PR TITLE
Use renv lock file of HADES-wide release 2024Q3 to install R packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
         openjdk-11-jdk libpcre2-dev zlib1g-dev liblzma-dev libbz2-dev libicu-dev libxml2-dev libncurses5-dev libffi-dev \
         make cmake libpng-dev libsodium-dev curl python3-dev python3-venv python3-pip \
-        libdeflate-dev unixodbc-dev libcurl4-openssl-dev xz-utils git pandoc supervisor \
+        libdeflate-dev unixodbc-dev libcurl4-openssl-dev xz-utils git pandoc \
         libsecret-1-0 \
 && R CMD javareconf
 
@@ -37,13 +37,13 @@ ARG HADES_RELEASE=2024Q3
 ARG RENV_LOCK=hadesWideReleases/$HADES_RELEASE/renv.lock
 COPY $RENV_LOCK /renv.lock
 
-# install OHDSI HADES R packages and additional model related R packages, Rserve server and client
+# install OHDSI HADES R packages and additional model related R packages, Rserve client
 # from CRAN and GitHub using a GitHub Personal Access Token (PAT)
 RUN --mount=type=secret,id=GITHUB_PAT,env=GITHUB_PAT \
     --mount=type=cache,target=/root/.cache/R/renv \
     Rscript --no-save --no-restore --no-echo \
     -e "library(renv); options(renv.verbose = TRUE); renv::restore(lockfile='/renv.lock')" \
-    -e "renv::install(c('usethis@3.1.0', 'gitcreds@0.1.2', 'xgboost@1.7.8.1', 'Rserve@1.8-13', 'RSclient@0.7-10'));"
+    -e "renv::install(c('usethis@3.1.0', 'gitcreds@0.1.2', 'xgboost@1.7.8.1', 'RSclient@0.7-10'));"
 
 # create Python virtual environment used by the OHDSI PatientLevelPrediction R package
 ENV WORKON_HOME="/opt/.virtualenvs"
@@ -72,20 +72,3 @@ COPY startRserve.R /usr/local/bin/startRserve.R
 RUN chmod +x /usr/local/bin/startRserve.R
 
 EXPOSE 8787
-EXPOSE 6311
-
-# start Rserve & RStudio using supervisor
-RUN echo "" >> /etc/supervisor/conf.d/supervisord.conf \
-    && echo "[supervisord]" >> /etc/supervisor/conf.d/supervisord.conf \
-    && echo "nodaemon=true" >> /etc/supervisor/conf.d/supervisord.conf \
-    && echo "" >> /etc/supervisor/conf.d/supervisord.conf \
-    && echo "[program:Rserve]" >> /etc/supervisor/conf.d/supervisord.conf \
-    && echo "command=/usr/local/bin/startRserve.R" >> /etc/supervisor/conf.d/supervisord.conf \
-    && echo "" >> /etc/supervisor/conf.d/supervisord.conf \
-    && echo "[program:RStudio]" >> /etc/supervisor/conf.d/supervisord.conf \
-    && echo "command=/init" >> /etc/supervisor/conf.d/supervisord.conf \
-    && echo "" >> /etc/supervisor/conf.d/supervisord.conf \
-    && echo "stdout_logfile=/var/log/supervisor/%(program_name)s.log" >> /etc/supervisor/conf.d/supervisord.conf \
-    && echo "stderr_logfile=/var/log/supervisor/%(program_name)s.log" >> /etc/supervisor/conf.d/supervisord.conf
-
-CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]


### PR DESCRIPTION
* Use binary CRAN repository with fixed CRAN snapshot date for reproducible package installation.
* Add system dependencies from Posit Package Manager.
* Use cache mount during build to reduce final image size.
* Work around issue with reticulate (install python3-virtualenv instead of python3-venv).

Also renv uses the binary package mirror by default. This overrides the setting from `renv.lock` files. Users can be undo this with
```R
options(renv.config.repos.override = NULL)
```