### PR TITLE
Add script to profile data in RDBMS supported for GHA testing

### DIFF
--- a/extras/DatabaseTestServerProfiling.R
+++ b/extras/DatabaseTestServerProfiling.R
@@ -1,0 +1,132 @@
+platforms <- read.csv("c:/git/ohdsi/Hades/extras/supportedPlatforms.csv", stringsAsFactors = FALSE)
+platforms <- platforms[order(platforms$platform), ]
+ghaPlatforms <- platforms[platforms$testingInGithubActions == 'Yes', ]
+
+# DatabaseConnector::downloadJdbcDrivers(
+#   dbms = "all"
+# )
+
+empty_value <- function(x) {
+  if (inherits(x, "Date")) {
+    as.Date(NA)
+  } else if (is.numeric(x)) {
+    NA_real_
+  } else if (is.integer(x)) {
+    NA_integer_
+  } else if (is.logical(x)) {
+    NA
+  } else {
+    "EMPTY"
+  }
+}
+
+dbInfo <- tibble::tibble()
+for (i in seq_len(nrow(ghaPlatforms))) {
+  dbms <- ghaPlatforms$abbreviation[i]
+  dbmsFormatted <- toupper(gsub(" ", "_", dbms))
+  cli::cli_inform(dbms)
+  # HACK for big query
+  if (dbms == "bigquery") {
+    dbmsFormatted = "BIG_QUERY"
+  }
+  # HACK for key
+  if (dbms %in% c("bigquery", "snowflake", "iris")) {
+    keyPrefix = "CDM_"
+  } else {
+    keyPrefix = "CDM5_"
+  }
+
+  userKey <- paste0(keyPrefix, dbmsFormatted, "_USER")
+  passwordKey <- paste0(keyPrefix, dbmsFormatted, "_PASSWORD")
+  serverKey <- paste0(keyPrefix, dbmsFormatted, "_SERVER")
+  connectionStringKey <- paste0(keyPrefix, dbmsFormatted, "_CONNECTION_STRING")
+  cdmSchemaKey <- paste0(keyPrefix, dbmsFormatted, "_CDM_SCHEMA")
+
+  # HACK For Snowflake
+  if (dbms == "snowflake") {
+    cdmSchemaKey <- paste0(keyPrefix, dbmsFormatted, "_CDM53_SCHEMA")
+  }
+
+  if (Sys.getenv(serverKey) == "" && Sys.getenv(connectionStringKey) == "") {
+    cli::cli_alert_warning("Skipping - no server/connection info found")
+    next
+  }
+
+  if (tolower(dbms) == "bigquery") {
+      bqKeyFile <- tempfile(fileext = ".json")
+      writeLines(Sys.getenv("CDM_BIG_QUERY_KEY_FILE"), bqKeyFile)
+      bqConnectionString <- gsub(
+        "<keyfile path>",
+        normalizePath(bqKeyFile, winslash = "/"),
+        Sys.getenv("CDM_BIG_QUERY_CONNECTION_STRING")
+      )
+      connectionDetails <- DatabaseConnector::createConnectionDetails(
+        dbms = "bigquery",
+        user = "",
+        password = "",
+        connectionString = !!bqConnectionString
+      )
+  } else if (Sys.getenv(connectionStringKey) != "") {
+    connectionDetails <- DatabaseConnector::createConnectionDetails(
+      dbms = dbms,
+      user = Sys.getenv(userKey),
+      password = URLdecode(Sys.getenv(passwordKey)),
+      connectionString = Sys.getenv(connectionStringKey)
+    )
+  } else {
+    connectionDetails <- DatabaseConnector::createConnectionDetails(
+      dbms = dbms,
+      user = Sys.getenv(userKey),
+      password = URLdecode(Sys.getenv(passwordKey)),
+      server = Sys.getenv(serverKey)
+    )
+  }
+  connection <- DatabaseConnector::connect(connectionDetails)
+  getCdmSourceInfoSql <- "SELECT * FROM @cdm_schema.cdm_source;"
+
+  cdmSourceInfo <- DatabaseConnector::renderTranslateQuerySql(
+    connection = connection,
+    sql = getCdmSourceInfoSql,
+    cdm_schema = Sys.getenv(cdmSchemaKey)
+  )
+
+  names(cdmSourceInfo) <- tolower(names(cdmSourceInfo))
+
+  if (nrow(cdmSourceInfo) == 0) {
+   cdmSourceInfo <- dplyr::bind_rows(
+      cdmSourceInfo,
+      tibble::as_tibble_row(purrr::map(cdmSourceInfo, empty_value))
+    )   
+  }
+
+  getCdmPersonCountSql <- "SELECT COUNT(*) person_cnt FROM @cdm_schema.person;"
+  totalPersonCount <- DatabaseConnector::renderTranslateQuerySql(
+    connection = connection,
+    sql = getCdmPersonCountSql,
+    cdm_schema = Sys.getenv(cdmSchemaKey)
+  )
+  names(totalPersonCount) <- tolower(names(totalPersonCount))
+
+  getObsPeriodRangeSql <- "
+    SELECT 
+      MIN(observation_period_start_date) obs_period_start_date
+      , MAX(observation_period_end_date) obs_period_end_date
+      FROM @cdm_schema.observation_period;
+  "
+
+  obsPeriodRange <- DatabaseConnector::renderTranslateQuerySql(
+    connection = connection,
+    sql = getObsPeriodRangeSql,
+    cdm_schema = Sys.getenv(cdmSchemaKey)
+  )
+  names(obsPeriodRange) <- tolower(names(obsPeriodRange))
+
+  DatabaseConnector::disconnect(connection)
+  curDbInfo <- cbind(data.frame(dbms = c(dbms), cdmSourceInfo, totalPersonCount, obsPeriodRange))
+  dbInfo <- dplyr::bind_rows(
+    dbInfo,
+    curDbInfo
+  )
+}
+
+dbInfo

--- a/extras/supportedPlatforms.csv
+++ b/extras/supportedPlatforms.csv
@@ -1,5 +1,5 @@
 abbreviation,platform,status,testingInGithubActions
-bigquery,Google BigQuery,Supported,
+bigquery,Google BigQuery,Supported,Yes
 duckdb,DuckDB,Supported,Yes
 hive,Apache Hive,Deprecated,
 impala,Apache Impala,Deprecated,
@@ -8,8 +8,8 @@ oracle,Oracle,Supported,Yes
 pdw,Microsoft Parallel Data Warehouse,Deprecated,
 postgresql,PostgreSQL,Supported,Yes
 redshift,Amazon RedShift,Supported,Yes
-snowflake,Snowflake,Supported,
-spark,Apache Spark,Supported,
+snowflake,Snowflake,Supported,Yes
+spark,Apache Spark,Supported,Yes
 sql server,Microsoft SQL Server,Supported,Yes
 sqlite,SQLite,Supported,Yes
 synapse,Azure Synapse Analytics Dedicated,Supported,


### PR DESCRIPTION
Per #47, I created a simple utility script to profile the CDMs currently configured for testing across HADES packages. This script has a few assumptions and key findings which I'll lay out:

- The script hardcodes the path to `extras/supportedPlatforms.csv` since I was trying to use reprex to show the output of running this script. I can revise that if preferable.
- Environmental variables used to store each RDBMS keys are inconsistent as noted by the `# HACK`s in the script. I'd like to make this consistent when we move to testing with a consistent, synthetic CDM
- Some of the test DBs are set up with differing column casing so an additional hack in this script forces all returned valued for `dbInfo` to lowercase. We should be consistent and use lowercase for all tables/columns per https://github.com/OHDSI/CommonDataModel/issues/509#issuecomment-2025814246

I also updated `extras/supportedPlatforms.csv` to note where we have testing servers available for GitHub actions. Here is some metadata for the test DBs at the moment:

|dbms       |cdm_source_name                                        |cdm_holder                                     |cdm_release_date |cdm_version |vocabulary_version | person_cnt|obs_period_start_date |obs_period_end_date |
|:----------|:------------------------------------------------------|:----------------------------------------------|:----------------|:-----------|:------------------|----------:|:---------------------|:-------------------|
|redshift   |SynPUF 1k sample                                       |OHDSI                                          |2018-06-25       |v5.3.1      |v5.0 05-NOV-17     |       1000|2007-12-15            |2010-12-31          |
|spark      |Synthea synthetic health database                      |OHDSI Community                                |2019-05-25       |v5.3.1      |v5.0 18-JAN-19     |       2694|1908-09-22            |2019-07-03          |
|bigquery   |Synthetic Public Use File                              |CMS                                            |2010-12-31       |NA          |                   |    2326856|2007-11-27            |2010-12-31          |
|iris       |EMPTY                                                  |EMPTY                                          |NA               |EMPTY       |EMPTY              |          0|NA                    |NA                  |
|sql server |Synpuf                                                 |ohdsi                                          |2018-03-15       |v5.4        |v5.0 29-APR-16     |       1000|2008-01-01            |2010-12-31          |
|oracle     |Synpuf                                                 |ohdsi                                          |2018-03-15       |v5.4        |v5.0 29-APR-16     |       1000|2008-01-01            |2010-12-31          |
|postgresql |Synpuf                                                 |ohdsi                                          |2018-03-15       |v5.4        |v5.0 29-APR-16     |       1000|2008-01-01            |2010-12-31          |
|snowflake  |CMS Synthetic Public Use Files (SynPUFs) - 110k Sample |Centers for Medicare & Medicaid Services (CMS) |2025-07-08       |5.3         |v5.0 31-JUL-20     |     116352|2007-11-27            |2010-12-31          |

Findings:

- Inconsistent synthetic data sets are used across the platforms: different sizes/flavors of SynPUF/Synthea.
- IRIS is missing data all together
- Different vocabulary versions

I stopped short of checking the integrity of the tables/columns since I think this script is useful to start and can be expanded once we fully implement the actions in #47. Just putting this PR out for reference in that issue.